### PR TITLE
Identation and reverting unnecessary fix

### DIFF
--- a/src/commands/getProfile.ts
+++ b/src/commands/getProfile.ts
@@ -9,7 +9,7 @@ const prisma = new PrismaClient()
  * 
  * @returns {Promise<User>}
  */
-export async function getProfile(username: string, isSubscriber = "false"): Promise<User> {
+export async function getProfile(username: string, isSubscriber: string = "false"): Promise<User> {
 
     const findUserByUserName = await prisma.user.findMany({
         where: {

--- a/src/interfaces/Spotify.ts
+++ b/src/interfaces/Spotify.ts
@@ -44,7 +44,7 @@ async function refreshToken() {
 }
 
 //Code grant generator function | Called by a GET request
- function generateCodeGrant() {
+function generateCodeGrant() {
     let scopes = ['user-modify-playback-state', 'user-read-currently-playing', 'user-read-playback-state'],
         state = rand(16);
 
@@ -108,7 +108,7 @@ async function getMusicName(trackId: string): Promise<string> {
     let musicData = "";
 
     await axios.get(url, { headers: headers })
-        .then( (res: any) => {
+        .then((res: any) => {
             musicData = `${res.data.artists[0].name} - ${res.data.name}`;
         })
         .catch(async (err: any) => {
@@ -143,9 +143,9 @@ async function currentPlayingTrackId(): Promise<string> {
     }
 
     let currentPlayingTrackId = "";
-    
+
     await axios.get(url, { headers: headers })
-        .then( (res: any) => {
+        .then((res: any) => {
             currentPlayingTrackId = res.data && res.data.item ? res.data.item.id : "";
         })
         .catch(async (err: any) => {
@@ -194,7 +194,7 @@ async function searchTrack(userId: number, search: string) {
         let results: any = [];
 
         await axios.get(url, { headers: headers })
-            .then( (res: any) => {
+            .then((res: any) => {
                 foundResults = res.data.tracks.items;
             })
             .catch(async (err: any) => {

--- a/src/twurple.ts
+++ b/src/twurple.ts
@@ -13,10 +13,10 @@ import { getProfile } from "./commands/getProfile";
 
 const prisma = new PrismaClient()
 
-export class TwIntegration {    
+export class TwIntegration {
     protected isTest?: boolean;
     protected chatClient: ChatClient
-    protected apiClient: ApiClient;    
+    protected apiClient: ApiClient;
 
     public constructor(isTest?: boolean) {
         this.isTest = isTest;
@@ -24,7 +24,7 @@ export class TwIntegration {
     async pubSub() {
         try {
             const clientId = process.env.TWITCH_CLIENT_ID as string;
-            const clientSecret = process.env.TWITCH_SECRET as string;          
+            const clientSecret = process.env.TWITCH_SECRET as string;
             const tokenData = JSON.parse(await fs.readFile("./src/jsons/twitch_main_tokens.json", "utf-8"));
 
             const authProvider = new RefreshingAuthProvider(
@@ -41,9 +41,9 @@ export class TwIntegration {
 
             await pubSubClient.onRedemption(userId, this.onRedemptionMessage.bind(this));
 
-            const apiClient = new ApiClient({authProvider: authProvider});
-            this.apiClient = apiClient;        
-            
+            const apiClient = new ApiClient({ authProvider: authProvider });
+            this.apiClient = apiClient;
+
         } catch (e) {
             console.error(e);
         }
@@ -117,7 +117,7 @@ export class TwIntegration {
 
         if (rewardId == process.env.TWITCH_REQUEST_SPOTIFY_REWARD_ID) {
 
-            await onSongRequest(profile.id, userName, message, "store").then( (songRequest) => {
+            await onSongRequest(profile.id, userName, message, "store").then((songRequest) => {
                 if (songRequest.errorMsg == "refuse_redemption") {
                     this.apiClient.channelPoints.updateRedemptionStatusByIds(channelId, rewardId, [id], "CANCELED");
                     this.sendChatMessage(songRequest.message);
@@ -152,7 +152,7 @@ export class TwIntegration {
     }
 
     // Function to send a message in the chat
-     sendChatMessage(message: string) {
+    sendChatMessage(message: string) {
         if (this.isTest) {
             console.log(message);
             return;


### PR DESCRIPTION
Moving some JSDoc to TypeScript. This was 'fixed' by a bot, then it is reverted now.

## Additions

- General code identation

## Changes

- Changing JSDoc function signature to TS type.